### PR TITLE
FYI: add optional creation of index with tenant field

### DIFF
--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -64,8 +64,22 @@ module Mongoid
 
         # Redefine 'index' to include the tenant field in first position
         def index(spec, options = nil)
-          spec = { self.tenant_field => 1 }.merge(spec)
+          spec = index_spec_for_options(spec, options)
           super(spec, options)
+        end
+
+        def index_spec_for_options(spec, options = nil)
+          set_compound_index = if options
+            options.delete(:multitenancy)
+          else
+            true
+          end
+
+          if set_compound_index
+            { self.tenant_field => 1 }.merge(spec)
+          else
+            spec
+          end
         end
 
         # Redefine 'delete_all' to take in account the default scope

--- a/spec/index_options_spec.rb
+++ b/spec/index_options_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe 'Index Options' do
+
+  let(:klass) do
+    Class.new do
+      include Mongoid::Multitenancy::Document
+    end
+  end
+
+  let(:index) { {title: 1}}
+
+  before do
+    klass.tenant_field = :client_id
+  end
+
+  describe '#index_for_options' do
+    context 'without multitenancy option' do
+      it 'adds the tenant field index by default' do
+        options = nil
+        expect(klass.index_spec_for_options(index, options)).to eq({client_id: 1, title: 1})
+      end
+    end
+
+    context 'with enabled multitenancy option' do
+      it 'adds the tenant field index to the compound' do
+        options = {multitenancy: true}
+        expect(klass.index_spec_for_options(index, options)).to eq({client_id: 1, title: 1})
+      end
+    end
+
+    context 'with disabled multitenancy option' do
+      it 'omits the tenant field from the index' do
+        options = {multitenancy: false}
+        expect(klass.index_spec_for_options(index, options)).to eq({title: 1})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Mit `multitenancy: false` kann man nun verhindern, dass mongoid-multitenancy automatisch nur den Compound Index mit der Client-ID anlegt. Möchte man beide Varianten, kann man zwei verschiedene Indexes definieren.
